### PR TITLE
Remove .builtInUltraWideCamera to improve capturing smaller QR codes

### DIFF
--- a/Sources/WalletSdk/ui/QRCodeScanner.swift
+++ b/Sources/WalletSdk/ui/QRCodeScanner.swift
@@ -266,7 +266,7 @@ public struct QRCodeScanner: View {
         do {
             /// Finding back camera
             guard let device = AVCaptureDevice.DiscoverySession(
-                    deviceTypes: [.builtInUltraWideCamera, .builtInWideAngleCamera],
+                    deviceTypes: [.builtInWideAngleCamera],
                     mediaType: .video, position: .back)
                 .devices.first
             else {

--- a/SpruceIDWalletSdk.podspec
+++ b/SpruceIDWalletSdk.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "SpruceIDWalletSdk"
-  spec.version      = "0.0.7"
+  spec.version      = "0.0.8"
   spec.summary      = "Swift Wallet SDK."
   spec.description  = <<-DESC
                    SpruceID Swift Wallet SDK.


### PR DESCRIPTION
This PR removes .builtInUltraWideCamera and makes it so that only the WideCamera is used. This camera has a better default zoom ratio, making capturing smaller QR codes easier.