### PR TITLE
Deep Link Instructions for Same Device Presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,7 @@ called in native SDKs.
 - [Kotlin SDK](https://github.com/spruceid/mobile-sdk-kt)
 - [Swift SDK](https://github.com/spruceid/mobile-sdk-swift)
 - [Rust layer](https://github.com/spruceid/mobile-sdk-rs)
+
+## Configuring Deep Links for same device flows
+
+Click [here](./Sources/MobileSdk/ui/SameDeviceOID4VP.md) to see how to configure the same device OpenID4VP flow.

--- a/Sources/MobileSdk/ui/SameDeviceOID4VP.md
+++ b/Sources/MobileSdk/ui/SameDeviceOID4VP.md
@@ -1,0 +1,30 @@
+# Same Device OpenID4VP
+
+If you already have the OpenID4VP working on your app, you need to configure a deep link to get the `openid4vp://` URL and start the flow.
+
+## Configuring the app Info
+
+1. Go to the Info tab
+2. Find the "URL Types" section and click on the add symbol (+) to create a new one
+3. Fill the "Identifier" field with anything that you want to help you identify this URL type (e.g., OID4VP)
+4. Fill the "URL Schemes" field with `openid4vp`
+
+## Handle the Deep Link
+
+Add the following to your `@main struct : App`.
+
+```swift
+@main
+struct MyApp: App {
+  var body: some Scene {
+    WindowGroup {
+      ContentView()
+        .onOpenURL { url in
+          // OID4VP flow integration
+        }
+    }
+  }
+}
+```
+
+And now your app is ready to handle `openid4vp://` URLs!


### PR DESCRIPTION
This adds instructions on configuring the same device presentation on iOS apps.