### PR TITLE
Make CredentialPack compatible with BLESessionManager

### DIFF
--- a/Sources/MobileSdk/MDoc.swift
+++ b/Sources/MobileSdk/MDoc.swift
@@ -63,6 +63,7 @@ public class BLESessionManager {
     // Cancel the request mid-transaction and gracefully clean up the BLE stack.
     public func cancel() {
         bleManager.disconnectFromDevice()
+        self.callback.update(state: .canceled)
     }
 
     public func submitNamespaces(items: [String: [String: [String]]]) {
@@ -168,4 +169,6 @@ public enum BLESessionState {
     case uploadProgress(Int, Int)
     /// App should display a success message and offer to close the page
     case success
+    /// App should display a canceled message
+    case canceled
 }

--- a/SpruceIDMobileSdk.podspec
+++ b/SpruceIDMobileSdk.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "SpruceIDMobileSdk"
-  spec.version      = "0.0.10"
+  spec.version      = "0.0.11"
   spec.summary      = "Swift Mobile SDK."
   spec.description  = <<-DESC
                    SpruceID Swift Mobile SDK.


### PR DESCRIPTION
This updates the CredentialPack.addMDoc method to make it compatible with the BLESessionManager and adds a new `canceled` status.