### PR TITLE
Expose public OID4VCI HTTP clients initializers

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,8 +14,8 @@ let package = Package(
             targets: ["SpruceIDMobileSdk"])
     ],
     dependencies: [
-        // .package(url: "https://github.com/spruceid/mobile-sdk-rs.git", exact: "0.0.33"),
-        .package(path: "../mobile-sdk-rs"),
+        .package(url: "https://github.com/spruceid/mobile-sdk-rs.git", exact: "0.0.36"),
+        // .package(path: "../mobile-sdk-rs"),
         .package(url: "https://github.com/apple/swift-algorithms", from: "1.2.0")
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -14,8 +14,8 @@ let package = Package(
             targets: ["SpruceIDMobileSdk"])
     ],
     dependencies: [
-        .package(url: "https://github.com/spruceid/mobile-sdk-rs.git", exact: "0.0.32"),
-        // .package(path: "../mobile-sdk-rs"),
+        // .package(url: "https://github.com/spruceid/mobile-sdk-rs.git", exact: "0.0.32"),
+        .package(path: "../mobile-sdk-rs"),
         .package(url: "https://github.com/apple/swift-algorithms", from: "1.2.0")
     ],
     targets: [

--- a/Sources/MobileSdk/OID4VCI.swift
+++ b/Sources/MobileSdk/OID4VCI.swift
@@ -3,6 +3,8 @@ import Foundation
 import SpruceIDMobileSdkRs
 
 public class Oid4vciSyncHttpClient: SyncHttpClient {
+    public init() {}
+    
     public func httpClient(request: HttpRequest) throws -> HttpResponse {
         guard let url = URL(string: request.url) else {
             throw HttpClientError.Other(error: "failed to construct URL")
@@ -74,6 +76,8 @@ public class Oid4vciSyncHttpClient: SyncHttpClient {
 }
 
 public class Oid4vciAsyncHttpClient: AsyncHttpClient {
+    public init() {}
+
     public func httpClient(request: HttpRequest) async throws -> HttpResponse {
         guard let url = URL(string: request.url) else {
             throw HttpClientError.Other(error: "failed to construct URL")

--- a/Sources/MobileSdk/OID4VCI.swift
+++ b/Sources/MobileSdk/OID4VCI.swift
@@ -4,7 +4,7 @@ import SpruceIDMobileSdkRs
 
 public class Oid4vciSyncHttpClient: SyncHttpClient {
     public init() {}
-    
+
     public func httpClient(request: HttpRequest) throws -> HttpResponse {
         guard let url = URL(string: request.url) else {
             throw HttpClientError.Other(error: "failed to construct URL")

--- a/SpruceIDMobileSdk.podspec
+++ b/SpruceIDMobileSdk.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "SpruceIDMobileSdk"
-  spec.version      = "0.0.11"
+  spec.version      = "0.0.12"
   spec.summary      = "Swift Mobile SDK."
   spec.description  = <<-DESC
                    SpruceID Swift Mobile SDK.

--- a/SpruceIDMobileSdk.podspec
+++ b/SpruceIDMobileSdk.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |spec|
   spec.source_files  = "Sources/MobileSdk/*.swift"
 
   spec.static_framework = true
-  spec.dependency 'SpruceIDMobileSdkRs', "~> 0.0.33"
+  spec.dependency 'SpruceIDMobileSdkRs', "~> 0.0.36"
   spec.dependency 'SwiftAlgorithms', "~> 1.0.0"
   spec.frameworks = 'Foundation', 'CoreBluetooth', 'CryptoKit'
 end


### PR DESCRIPTION
Depends on https://github.com/spruceid/mobile-sdk-rs/pull/56 

This exposes the `Oid4vciSyncHttpClient` and `Oid4vciAsyncHttpClient` initializers that allow creation on the apps. This also needs to bump the mobile-sdk-rs dependency to make it compatible to the mobile-sdk-ios-app PR (https://github.com/spruceid/mobile-sdk-ios-app/pull/22)

