### PR TITLE
Address a few bugs in IsoMdlPresentation and modify MDoc

### DIFF
--- a/Sources/MobileSdk/IsoMdlPresentation.swift
+++ b/Sources/MobileSdk/IsoMdlPresentation.swift
@@ -49,40 +49,14 @@ public class IsoMdlPresentation {
         bleManager.disconnectFromDevice(session: self.session)
     }
 
-    public func submitNamespaces(items: [String: [String: [String]]]) {
+    public func submitNamespaces(items: [String: [String: [String]]], signingKey: SecKey) {
         do {
             let payload = try session.generateResponse(permittedItems: items)
 
-            let tag = self.mdoc.keyAlias.data(using: .utf8)!
-            let query: [String: Any] = [
-                kSecClass as String: kSecClassKey,
-                kSecAttrApplicationTag as String: tag,
-                kSecAttrKeyType as String: kSecAttrKeyTypeECSECPrimeRandom,
-                kSecReturnRef as String: true,
-            ]
-
-            // Find and cast the result as a SecKey instance.
-            var item: CFTypeRef?
-            var secKey: SecKey
-            switch SecItemCopyMatching(query as CFDictionary, &item) {
-            case errSecSuccess:
-                // swiftlint:disable force_cast
-                secKey = item as! SecKey
-            // swiftlint:enable force_cast
-            case errSecItemNotFound:
-                self.callback.update(state: .error(.generic("Key not found")))
-                self.cancel()
-                return
-            case let status:
-                self.callback.update(
-                    state: .error(.generic("Keychain read failed: \(status)")))
-                self.cancel()
-                return
-            }
             var error: Unmanaged<CFError>?
             guard
                 let derSignature = SecKeyCreateSignature(
-                    secKey,
+                    signingKey,
                     .ecdsaSignatureMessageX962SHA256,
                     payload as CFData,
                     &error) as Data?

--- a/Sources/MobileSdk/IsoMdlPresentation.swift
+++ b/Sources/MobileSdk/IsoMdlPresentation.swift
@@ -19,7 +19,7 @@ public class IsoMdlPresentation {
     var bleManager: MDocHolderBLECentral!
     var useL2CAP: Bool
 
-    init?(
+    public init?(
         mdoc: MDoc, engagement: DeviceEngagement,
         callback: BLESessionStateDelegate, useL2CAP: Bool
     ) async {

--- a/Sources/MobileSdk/IsoMdlPresentation.swift
+++ b/Sources/MobileSdk/IsoMdlPresentation.swift
@@ -52,12 +52,14 @@ public class IsoMdlPresentation {
     public func submitNamespaces(items: [String: [String: [String]]]) {
         do {
             let payload = try session.generateResponse(permittedItems: items)
-            let query =
-                [
-                    kSecClass: kSecClassKey,
-                    kSecAttrApplicationLabel: self.mdoc.keyAlias,
-                    kSecReturnRef: true
-                ] as [String: Any]
+
+            let tag = self.mdoc.keyAlias.data(using: .utf8)!
+            let query: [String: Any] = [
+                kSecClass as String: kSecClassKey,
+                kSecAttrApplicationTag as String: tag,
+                kSecAttrKeyType as String: kSecAttrKeyTypeECSECPrimeRandom,
+                kSecReturnRef as String: true,
+            ]
 
             // Find and cast the result as a SecKey instance.
             var item: CFTypeRef?

--- a/Sources/MobileSdk/MDoc.swift
+++ b/Sources/MobileSdk/MDoc.swift
@@ -15,7 +15,7 @@ public class MDoc: Credential {
   /// IssuerSignedItemBytes will be bytes, but its composition is defined here
   /// https://github.com/spruceid/isomdl/blob/f7b05dfa/src/definitions/issuer_signed.rs#L18
   public init?(
-    fromMDoc issuerAuth: Data, keyAlias: String
+    fromMDoc mdocBytes: Data, keyAlias: String
   ) {
     self.keyAlias = keyAlias
     do {

--- a/Sources/MobileSdk/MDoc.swift
+++ b/Sources/MobileSdk/MDoc.swift
@@ -15,8 +15,7 @@ public class MDoc: Credential {
   /// IssuerSignedItemBytes will be bytes, but its composition is defined here
   /// https://github.com/spruceid/isomdl/blob/f7b05dfa/src/definitions/issuer_signed.rs#L18
   public init?(
-    fromMDoc issuerAuth: Data, namespaces: [MDocNamespace: [IssuerSignedItemBytes]],
-    keyAlias: String
+    fromMDoc issuerAuth: Data, keyAlias: String
   ) {
     self.keyAlias = keyAlias
     do {

--- a/Sources/MobileSdk/MDoc.swift
+++ b/Sources/MobileSdk/MDoc.swift
@@ -20,7 +20,7 @@ public class MDoc: Credential {
     self.keyAlias = keyAlias
     do {
       try self.inner = SpruceIDMobileSdkRs.Mdoc.fromCborEncodedDocument(
-        cborEncodedDocument: issuerAuth, keyAlias: keyAlias)
+        cborEncodedDocument: mdocBytes, keyAlias: keyAlias)
     } catch {
       print("\(error)")
       return nil


### PR DESCRIPTION
Makes IsoMdlPresentation init public and adjusts the code that retrieves the signing key from the key store to match that which is currently in the CA DMV wallet. Also removes an unused init argument from the MDoc init function and renames another argument.